### PR TITLE
Refactor Firebase initialization and update auth usage

### DIFF
--- a/frontend/src/app/booking/confirmbooking/[classid]/page.js
+++ b/frontend/src/app/booking/confirmbooking/[classid]/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import axios from "axios";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import {
   calculateTotalPayable,
@@ -34,7 +34,12 @@ export default function BookingConfirmation() {
 
   // Firebase auth listener - only students should access booking pages
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setAuthLoading(false);

--- a/frontend/src/app/booking/success/page.js
+++ b/frontend/src/app/booking/success/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 
 export default function BookingSuccess() {
@@ -16,7 +16,12 @@ export default function BookingSuccess() {
 
   // Firebase auth listener - only students should access booking pages
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setAuthLoading(false);

--- a/frontend/src/app/explore/group-batches/page.js
+++ b/frontend/src/app/explore/group-batches/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import { calculateTotalPayable, formatPrice } from '../../utils/pricingCalculator';
 import ChildSelectionModal from '@/components/ChildSelectionModal';
@@ -283,7 +283,12 @@ export default function GroupBatches() {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         

--- a/frontend/src/app/explore/onetoone/page.js
+++ b/frontend/src/app/explore/onetoone/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import ChildSelectionModal from '@/components/ChildSelectionModal';
 
@@ -142,10 +142,15 @@ export default function OneOnOneSessions() {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
-        
+
         try {
           const idToken = await currentUser.getIdToken();
           const profileResponse = await axios.get(

--- a/frontend/src/app/explore/workshops/page.js
+++ b/frontend/src/app/explore/workshops/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import { calculateTotalPayable, formatPrice } from '../../utils/pricingCalculator';
 import ChildSelectionModal from '@/components/ChildSelectionModal';
@@ -332,7 +332,12 @@ export default function Workshops() {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         

--- a/frontend/src/app/getstarted/[mentor]/page.js
+++ b/frontend/src/app/getstarted/[mentor]/page.js
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import axios from 'axios';
 // Firebase imports
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { auth } from '../../../lib/firebase';
+import { getFirebaseAuth } from '../../../lib/firebase';
 
 const AuthPages = () => {
   // State to manage which tab is active: 'signin' or 'signup'
@@ -41,7 +41,15 @@ const AuthPages = () => {
   // State to track form validation errors
   const [signupFormErrors, setSignupFormErrors] = useState({});
   const [signinFormErrors, setSigninFormErrors] = useState({});
-  
+
+  const getAuthOrThrow = () => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      throw new Error('Firebase auth not available');
+    }
+    return authInstance;
+  };
+
   // Check URL parameters and set the active tab on component mount
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -82,6 +90,7 @@ const AuthPages = () => {
   // Helper function to make authenticated API calls to backend
   const makeAuthenticatedAPICall = async (endpoint, method = 'GET', data = null) => {
     try {
+      const auth = getAuthOrThrow();
       const user = auth.currentUser;
       console.log('API Call - Current user:', user?.uid);
       
@@ -155,6 +164,11 @@ const AuthPages = () => {
     try {
       console.log('Starting Firebase mentor signup process...');
       
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error('Firebase auth not available');
+      }
+
       // Step 1: Create Firebase user
       const userCredential = await createUserWithEmailAndPassword(auth, signupEmail, signupPassword);
       const firebaseUser = userCredential.user;
@@ -237,6 +251,11 @@ const AuthPages = () => {
     try {
       console.log('Starting Firebase mentor signin process...');
       
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error('Firebase auth not available');
+      }
+
       // Step 1: Sign in with Firebase
       const userCredential = await signInWithEmailAndPassword(auth, signinEmail, signinPassword);
       const firebaseUser = userCredential.user;

--- a/frontend/src/app/getstarted/page.js
+++ b/frontend/src/app/getstarted/page.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import Navbar from '@/components/NavBar';
 // Firebase imports
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { auth } from '../../lib/firebase';
+import { getFirebaseAuth } from '../../lib/firebase';
 
 const AuthPages = () => {
 
@@ -45,7 +45,15 @@ const AuthPages = () => {
   // State to track form validation errors
   const [signupFormErrors, setSignupFormErrors] = useState({});
   const [signinFormErrors, setSigninFormErrors] = useState({});
-  
+
+  const getAuthOrThrow = () => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      throw new Error('Firebase auth not available');
+    }
+    return authInstance;
+  };
+
   // Check URL parameters and set the active tab on component mount
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -87,6 +95,7 @@ const AuthPages = () => {
   // Helper function to make authenticated API calls to backend
   const makeAuthenticatedAPICall = async (endpoint, method = 'GET', data = null) => {
     try {
+      const auth = getAuthOrThrow();
       const user = auth.currentUser;
       console.log('API Call - Current user:', user?.uid);
       
@@ -159,7 +168,12 @@ const AuthPages = () => {
 
     try {
       console.log('Starting Firebase signup process...');
-      
+
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error('Firebase auth not available');
+      }
+
       // Step 1: Create Firebase user
       const userCredential = await createUserWithEmailAndPassword(auth, signupEmail, signupPassword);
       const firebaseUser = userCredential.user;
@@ -241,7 +255,12 @@ const AuthPages = () => {
 
     try {
       console.log('Starting Firebase signin process...');
-      
+
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error('Firebase auth not available');
+      }
+
       // Step 1: Sign in with Firebase
       const userCredential = await signInWithEmailAndPassword(auth, signinEmail, signinPassword);
       const firebaseUser = userCredential.user;

--- a/frontend/src/app/mentor/hostaclass/page.js
+++ b/frontend/src/app/mentor/hostaclass/page.js
@@ -4,7 +4,7 @@ import Head from "next/head";
 import MentorSideBase from "@/components/MentorSideBase";
 import { navItems } from "@/app/utils";
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 // Re-creating the Tailwind config for use in the component
@@ -105,7 +105,12 @@ const HostClassPage = () => {
 
   // Firebase auth and setup
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         // Set mentorId in form data

--- a/frontend/src/app/mentor/messages/page.js
+++ b/frontend/src/app/mentor/messages/page.js
@@ -3,7 +3,7 @@
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import axios from "axios";
 import { useState, useEffect, useRef } from "react";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 // Using inline SVG for FontAwesome icons as Next.js does not support direct link to CSS in components
@@ -283,7 +283,12 @@ const Messages = () => {
       setStudentList(students);
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         fetchMentorClasses(currentUser);

--- a/frontend/src/app/mentor/myclass/page.js
+++ b/frontend/src/app/mentor/myclass/page.js
@@ -6,7 +6,7 @@ import MentorSideBase from "@/components/MentorSideBase";
 import { navItems } from "@/app/utils";
 import axios from "axios";
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 export default function MyClass() {
@@ -122,7 +122,12 @@ export default function MyClass() {
       }
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         // Get mentor details from localStorage (set by dashboard)

--- a/frontend/src/app/mentor/onboarding/page.js
+++ b/frontend/src/app/mentor/onboarding/page.js
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import axios from "axios";
 
@@ -93,7 +93,13 @@ const OnBoarding = () => {
 
   // Firebase auth state listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      setLoading(false);
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       setUser(currentUser);
       setLoading(false);
       if (currentUser) {

--- a/frontend/src/app/mentor/schedule/page.js
+++ b/frontend/src/app/mentor/schedule/page.js
@@ -6,7 +6,7 @@ import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import MentorSideBase from "@/components/MentorSideBase";
 import { navItems } from "@/app/utils";
 import MentorAvailability from "@/components/MentorAvailability";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 export default function Schedule() {
@@ -186,7 +186,12 @@ export default function Schedule() {
   };
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setMentorId(currentUser.uid);

--- a/frontend/src/app/mentor/students/page.js
+++ b/frontend/src/app/mentor/students/page.js
@@ -6,7 +6,7 @@ import MentorSideBase from "@/components/MentorSideBase";
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import { navItems } from "@/app/utils";
 import axios from "axios";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 export default function Students() {
@@ -42,7 +42,12 @@ export default function Students() {
   };
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (!currentUser) {
         // Not authenticated, redirect to login
         window.location.href = '/getstarted';
@@ -270,7 +275,12 @@ export default function Students() {
       }
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         fetchStudents(currentUser);
       } else {

--- a/frontend/src/app/user/bookings/page.js
+++ b/frontend/src/app/user/bookings/page.js
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import { getSessionsSummary } from "@/app/utils";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 const Dashboard = () => {
@@ -93,7 +93,12 @@ const Dashboard = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setUserProfile({

--- a/frontend/src/app/user/dashboard/page.js
+++ b/frontend/src/app/user/dashboard/page.js
@@ -3,7 +3,7 @@ import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import UserSidebar from "@/components/UserSidebar";
 import axios from "axios";
 import React, { useState, useEffect, useRef } from "react";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 const Dashboard = () => {
@@ -36,7 +36,12 @@ const Dashboard = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         

--- a/frontend/src/app/user/messages/page.js
+++ b/frontend/src/app/user/messages/page.js
@@ -3,7 +3,7 @@
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
 import axios from "axios";
 import { useState, useEffect, useRef } from "react";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 // Using inline SVG for FontAwesome icons as Next.js does not support direct link to CSS in components
@@ -241,7 +241,12 @@ const Messages = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setLoading(false);

--- a/frontend/src/app/user/onboarding/page.js
+++ b/frontend/src/app/user/onboarding/page.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react";
 import Head from "next/head";
 import axios from "axios";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 const UserOnboardingFlow = () => {
@@ -20,7 +20,12 @@ const UserOnboardingFlow = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         setFormData((prev) => ({

--- a/frontend/src/app/user/savedmentors/page.js
+++ b/frontend/src/app/user/savedmentors/page.js
@@ -3,7 +3,7 @@ import UserSidebar from "@/components/UserSidebar";
 import React, { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import MentorHeaderAccount from "@/components/MentorHeaderAccount";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 const SavedMentorsPage = () => {
@@ -29,10 +29,15 @@ const SavedMentorsPage = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
-        
+
         try {
           // Fetch full user profile with roles
           const idToken = await currentUser.getIdToken();

--- a/frontend/src/app/user/younglearner/page.js
+++ b/frontend/src/app/user/younglearner/page.js
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect, useRef } from "react";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import axios from "axios";
 import UserSidebar from "@/components/UserSidebar";
@@ -34,10 +34,15 @@ const YoungLearnerPage = () => {
 
   // Firebase auth listener
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
-        
+
         try {
           const idToken = await currentUser.getIdToken();
           const profileResponse = await axios.get(

--- a/frontend/src/app/workshop/listing/page.js
+++ b/frontend/src/app/workshop/listing/page.js
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import Navbar from '@/components/NavBar';
 import axios from 'axios';
 import { useRouter } from 'next/navigation';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import ChildSelectionModal from '@/components/ChildSelectionModal';
 
@@ -32,7 +32,12 @@ export default function Home() {
 
   // Firebase auth listener with role fetching
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+    const authInstance = getFirebaseAuth();
+    if (!authInstance) {
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
         

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -3,7 +3,7 @@
  * Handles authentication, base URLs, error handling, and retry logic
  */
 
-import { auth } from './firebase';
+import { getFirebaseAuth } from './firebase';
 
 // Environment-based API URL detection
 const API_BASE_URL = process.env.NODE_ENV === 'production' 
@@ -18,10 +18,11 @@ console.log('API Base URL:', API_BASE_URL);
 const getFirebaseToken = async () => {
   try {
     // Guard against server-side rendering and missing auth
-    if (!auth || typeof window === 'undefined') {
+    const auth = getFirebaseAuth();
+    if (!auth) {
       throw new Error('Firebase auth not available (SSR or missing config)');
     }
-    
+
     const user = auth.currentUser;
     if (!user) {
       throw new Error('No authenticated user found');

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -1,10 +1,9 @@
 // frontend/src/lib/firebase.ts
 
-// Import the functions you need from the SDKs
-import { initializeApp, getApps, getApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
+import { initializeApp, getApps, getApp, type FirebaseApp } from "firebase/app";
+import { getAuth, type Auth } from "firebase/auth";
+import { getFirestore, type Firestore } from "firebase/firestore";
+import { getStorage, type FirebaseStorage } from "firebase/storage";
 
 // Firebase config from .env.local (automatically pulled via NEXT_PUBLIC_*)
 const firebaseConfig = {
@@ -17,21 +16,64 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-// Only initialize Firebase on the client side with valid config
-let app, auth, db, storage;
+let firebaseApp: FirebaseApp | null = null;
+let firebaseAuth: Auth | null = null;
+let firestore: Firestore | null = null;
+let storage: FirebaseStorage | null = null;
 
-if (typeof window !== 'undefined' && firebaseConfig.apiKey) {
-  // Client-side initialization with valid config
-  app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-  auth = getAuth(app);
-  db = getFirestore(app);
-  storage = getStorage(app);
-} else {
-  // Server-side or missing config - create placeholder objects
-  app = null;
-  auth = null;
-  db = null;
-  storage = null;
-}
+const hasValidConfig = Boolean(firebaseConfig.apiKey);
 
-export { app, auth, db, storage };
+export const getFirebaseApp = (): FirebaseApp | null => {
+  if (!hasValidConfig) {
+    return null;
+  }
+
+  if (!firebaseApp) {
+    firebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
+  }
+
+  return firebaseApp;
+};
+
+export const getFirebaseAuth = (): Auth | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  if (!firebaseAuth) {
+    firebaseAuth = getAuth(app);
+  }
+
+  return firebaseAuth;
+};
+
+export const getFirebaseFirestore = (): Firestore | null => {
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  if (!firestore) {
+    firestore = getFirestore(app);
+  }
+
+  return firestore;
+};
+
+export const getFirebaseStorage = (): FirebaseStorage | null => {
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  if (!storage) {
+    storage = getStorage(app);
+  }
+
+  return storage;
+};


### PR DESCRIPTION
## Summary
- memoize the Firebase app initialization and expose helpers for auth, Firestore, and storage access
- update the shared API client and auth-driven pages to fetch the auth instance inside effects before subscribing
- adjust student and mentor sign-up flows to create and reuse the auth instance on demand while handling null returns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1221add84832b96cd24e19c5da926